### PR TITLE
add `str wrap` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +556,29 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hyphenation"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf4dd4c44ae85155502a52c48739c8a48185d1449fff1963cffee63c28a50f0"
+dependencies = [
+ "bincode",
+ "fst",
+ "hyphenation_commons",
+ "pocket-resources",
+ "serde",
+]
+
+[[package]]
+name = "hyphenation_commons"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5febe7a2ade5c7d98eb8b75f946c046b335324b06a14ea0998271504134c05bf"
+dependencies = [
+ "fst",
+ "serde",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1054,6 +1092,7 @@ dependencies = [
  "nu-plugin-test-support",
  "nu-protocol",
  "textdistance",
+ "textwrap",
 ]
 
 [[package]]
@@ -1129,6 +1168,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pocket-resources"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c135f38778ad324d9e9ee68690bac2c1a51f340fdf96ca13e2ab3914eb2e51d8"
 
 [[package]]
 name = "powerfmt"
@@ -1655,6 +1700,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 dependencies = [
+ "hyphenation",
  "smawk",
  "unicode-linebreak",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ nu-path = "0.99.1"
 deunicode = "1.6.0"
 textdistance = "1.1.0"
 brotli = "7.0.0"
+textwrap = { version = "0.16.1", features = ["hyphenation", "unicode-width", "unicode-linebreak", "smawk"] }
 
 [dev-dependencies]
 nu-plugin-test-support = "0.99.1"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,9 +3,11 @@ mod str_compress;
 mod str_decompress;
 mod str_deunicode;
 mod str_similarity;
+mod str_wrap;
 
 // Command structs should be exported here
 pub use str_compress::StrCompress;
 pub use str_decompress::StrDecompress;
 pub use str_deunicode::StrDeunicode;
 pub use str_similarity::StrSimilarity;
+pub use str_wrap::StrWrap;

--- a/src/commands/str_wrap.rs
+++ b/src/commands/str_wrap.rs
@@ -1,0 +1,107 @@
+use nu_plugin::{EngineInterface, EvaluatedCall, SimplePluginCommand};
+use nu_protocol::{
+    Category, Example, LabeledError, ShellError, Signature, Span, SyntaxShape, Type, Value,
+};
+use textwrap::{fill, Options, WrapAlgorithm};
+
+use crate::StrutilsPlugin;
+
+pub struct StrWrap;
+
+impl SimplePluginCommand for StrWrap {
+    type Plugin = StrutilsPlugin;
+
+    fn name(&self) -> &str {
+        "str wrap"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_types(vec![(Type::String, Type::String)])
+            .switch(
+                "optimal-fit",
+                "Wrap words using an advanced algorithm with look-ahead.",
+                Some('o'),
+            )
+            .named(
+                "width",
+                SyntaxShape::Int,
+                "The width in columns at which the text will be wrapped. (default 80)",
+                Some('w'),
+            )
+            .category(Category::Strings)
+    }
+
+    fn description(&self) -> &str {
+        "Wrap text passed into pipeline."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["convert", "ascii"]
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "deunicode a string",
+            example: "'A…C' | str deunicode",
+            result: Some(Value::test_string("A...C")),
+        }]
+    }
+
+    fn run(
+        &self,
+        _plugin: &StrutilsPlugin,
+        _engine: &EngineInterface,
+        call: &EvaluatedCall,
+        input: &Value,
+    ) -> Result<Value, LabeledError> {
+        // dedent	Removes common leading whitespace from each line.
+        // fill	Fill a line of text at width characters.
+        // indent	Add prefix to each non-empty line.
+        // refill	Refill a paragraph of wrapped text with a new width.
+        // unfill	Unpack a paragraph of already-wrapped text.
+        // wrap	Wrap a line of text at width characters.
+
+        let optimal = call.has_flag("optimal-fit")?;
+        let width = call.get_flag("width")?.unwrap_or(80usize);
+
+        Ok(do_wrap(input, optimal, width, call.head))
+    }
+}
+
+fn do_wrap(input: &Value, optimal: bool, width: usize, head: Span) -> Value {
+    let options = Options::new(width).wrap_algorithm(if optimal {
+        WrapAlgorithm::new_optimal_fit()
+    } else {
+        WrapAlgorithm::FirstFit
+    });
+
+    match input {
+        // fill returns a string with the text wrapped at the specified width
+        // wrap returns a list of strings with the text wrapped at the specified width
+        Value::String { val, .. } => Value::string(fill(val, options), head),
+        Value::Error { .. } => input.clone(),
+        _ => Value::error(
+            ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: input.get_type().to_string(),
+                dst_span: head,
+                src_span: input.span(),
+            },
+            head,
+        ),
+    }
+}
+
+#[test]
+fn test_examples() -> Result<(), nu_protocol::ShellError> {
+    use nu_plugin_test_support::PluginTest;
+
+    // This will automatically run the examples specified in your command and compare their actual
+    // output against what was specified in the example.
+    //
+    // We recommend you add this test to any other commands you create, or remove it if the examples
+    // can't be tested this way.
+
+    PluginTest::new("strutils", StrutilsPlugin.into())?.test_command_examples(&StrWrap)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ impl Plugin for StrutilsPlugin {
             Box::new(StrSimilarity),
             Box::new(StrCompress),
             Box::new(StrDecompress),
+            Box::new(StrWrap),
         ]
     }
 }


### PR DESCRIPTION
Adds a `str wrap` functionality.

```nushell
❯ "now is the time for all good men to come to the aid of their country" | str wrap
now is the time for all good men to come to the aid of their country
❯ "now is the time for all good men to come to the aid of their country" | str wrap --width 10
now is the
time for
all good
men to
come to
the aid of
their
country
❯ "now is the time for all good men to come to the aid of their country" | str wrap --width 10 --optimal-fit
now is
the time
for all
good men
to come
to the aid
of their
country
```