### PR TITLE
add `str indent` command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@ mod str_compress;
 mod str_decompress;
 mod str_dedent;
 mod str_deunicode;
+mod str_indent;
 mod str_similarity;
 mod str_wrap;
 
@@ -11,5 +12,6 @@ pub use str_compress::StrCompress;
 pub use str_decompress::StrDecompress;
 pub use str_dedent::StrDedent;
 pub use str_deunicode::StrDeunicode;
+pub use str_indent::StrIndent;
 pub use str_similarity::StrSimilarity;
 pub use str_wrap::StrWrap;

--- a/src/commands/str_wrap.rs
+++ b/src/commands/str_wrap.rs
@@ -66,13 +66,6 @@ impl SimplePluginCommand for StrWrap {
         call: &EvaluatedCall,
         input: &Value,
     ) -> Result<Value, LabeledError> {
-        // dedent	Removes common leading whitespace from each line.
-        // fill	    Fill a line of text at width characters.
-        // indent	Add prefix to each non-empty line.
-        // refill	Refill a paragraph of wrapped text with a new width.
-        // unfill	Unpack a paragraph of already-wrapped text.
-        // wrap	Wrap a line of text at width characters.
-
         let optimal = call.has_flag("optimal-fit")?;
         let width = call.get_flag("width")?.unwrap_or(80usize);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ impl Plugin for StrutilsPlugin {
             Box::new(StrDecompress),
             Box::new(StrWrap),
             Box::new(StrDedent),
+            Box::new(StrIndent),
         ]
     }
 }


### PR DESCRIPTION
Add the `str indent` command
```nushell
❯ str indent --help
Indent each line by the given prefix.

Search terms: convert, ascii, dedent, tab

Usage:
  > str indent <prefix>

Flags:
  -h, --help: Display the help message for this command

Parameters:
  prefix <string>: Prefix used to indent each line with.

Input/output types:
  ╭─#─┬─input──┬─output─╮
  │ 0 │ string │ string │
  ╰───┴────────┴────────╯

Examples:
  Indent each line with a provided prefix
  > "First line.\nSecond line.\n" | str indent "1111"
  1111First line.
  1111Second line.
```