### PR TITLE
chore: Fix `str shlquote` test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,8 +1459,7 @@ dependencies = [
 [[package]]
 name = "shell-words"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+source = "git+https://github.com/tmiasko/shell-words?rev=efe8162286fd684e7e4e7552c6ec303446675318#efe8162286fd684e7e4e7552c6ec303446675318"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ brotli = "8.0.1"
 textwrap = { version = "0.16.2", features = ["hyphenation", "unicode-width", "unicode-linebreak", "smawk"] }
 flate2 = "1.1.2"
 slug = "0.1.6"
-shell-words = "1.1.0"
+shell-words = { git = "https://github.com/tmiasko/shell-words", rev = "efe8162286fd684e7e4e7552c6ec303446675318" }
 
 [dev-dependencies]
 nu-plugin-test-support = "0.106.0"


### PR DESCRIPTION
Tildes are not being quoted properly by shell-words on the latest crates.io release, but the issue is fixed on the upstream git repo, see https://github.com/tmiasko/shell-words/issues/18 .

fixes: https://github.com/fdncred/nu_plugin_strutils/issues/14